### PR TITLE
Update valid_url.rb

### DIFF
--- a/lib/valid_url.rb
+++ b/lib/valid_url.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "addressable/uri"
 require "resolv"
 


### PR DESCRIPTION
adds # -_\- encoding : utf-8 -_\- to be able to work in ruby 1.9
