### PR TITLE
Use I18n for the invalid URL error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  errors:
+    messages:
+      invalid_url: "is an invalid URL"

--- a/lib/valid_url.rb
+++ b/lib/valid_url.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+require "valid_url/engine"
 require "addressable/uri"
 require "resolv"
 
@@ -19,7 +20,7 @@ module ActiveModel
         end
 
         unless !invalid && valid_scheme?(uri.scheme) && valid_host?(uri.host) && valid_path?(uri.path)
-          record.errors[attribute] << (options[:message] || "is an invalid URL")
+          record.errors.add attribute, :invalid_url, options
         end
       end
 

--- a/lib/valid_url/engine.rb
+++ b/lib/valid_url/engine.rb
@@ -1,0 +1,7 @@
+module ValidUrl
+  class Engine < ::Rails::Engine
+    config.before_initialize do
+      config.i18n.load_path += Dir["#{config.root}/config/locales/**/*.yml"]
+    end
+  end
+end


### PR DESCRIPTION
This enables the error to be customised in the normal Rails manner, i.e. by setting `<locale>.errors.messages.invalid_url` or specifically for a model using `<locale>.activerecord.errors.models.<model>.attributes.<field>.invalid_url`.